### PR TITLE
Reverted timingApi version number

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -5,8 +5,8 @@ RELEASE_NOTES for spectrometer module
 See README for module info
 #==============================================================
 
-R1.2.0 01-10-2025 Jane Liu (janeliu-slac)
-    Updated to asyn/R4.42-1.0.0, evrClient/R1.5.5, timingApi/R0.11
+R1.0.6 01-10-2025 Jane Liu (janeliu-slac)
+    Updated to asyn/R4.42-1.0.0
     Added support for seabreeze 3.0.11 on Rocky 9
 
 R1.1.0  18-Nov-2024  M. Dunning (mdunning)

--- a/configure/RELEASE.local
+++ b/configure/RELEASE.local
@@ -32,9 +32,7 @@ TIMINGAPI_MODULE_VERSION = R0.9
 ASYN = $(EPICS_MODULES)/asyn/$(ASYN_MODULE_VERSION)
 
 ifeq ($(findstring pcds,$(FACILITY_ROOT)),)
-    #EVRCLIENT = $(EPICS_MODULES)/evrClient/$(EVRCLIENT_MODULE_VERSION)
-    EVRCLIENT = /cds/home/j/janeliu/git/slac-epics/evrClient
-
+    EVRCLIENT = $(EPICS_MODULES)/evrClient/$(EVRCLIENT_MODULE_VERSION)
     TIMINGAPI = $(EPICS_MODULES)/timingApi/$(TIMINGAPI_MODULE_VERSION)
 endif
 

--- a/configure/RELEASE.local
+++ b/configure/RELEASE.local
@@ -20,19 +20,21 @@
 # could match a directory name.
 # ==========================================================
 ASYN_MODULE_VERSION = R4.42-1.0.0
-EVRCLIENT_MODULE_VERSION = R1.5.5
-TIMINGAPI_MODULE_VERSION = R0.11
+EVRCLIENT_MODULE_VERSION = R1.5.4
+TIMINGAPI_MODULE_VERSION = R0.9
 
 # ==========================================================
 # Define module paths using pattern
 # FOO = $(EPICS_MODULES)/foo/$(FOO_MODULE_VERSION)
 #  or
 # FOO = /Full/Path/To/Development/Version 
-# ==========================================================)
+# ==========================================================
 ASYN = $(EPICS_MODULES)/asyn/$(ASYN_MODULE_VERSION)
 
 ifeq ($(findstring pcds,$(FACILITY_ROOT)),)
-    EVRCLIENT = $(EPICS_MODULES)/evrClient/$(EVRCLIENT_MODULE_VERSION)
+    #EVRCLIENT = $(EPICS_MODULES)/evrClient/$(EVRCLIENT_MODULE_VERSION)
+    EVRCLIENT = /cds/home/j/janeliu/git/slac-epics/evrClient
+
     TIMINGAPI = $(EPICS_MODULES)/timingApi/$(TIMINGAPI_MODULE_VERSION)
 endif
 


### PR DESCRIPTION
I'm currently working on migrating `ioc-common-OceanOpticsSpectrometer` to Rocky 9. This IOC has a complex dependency chain: `ioc-common-OceanOpticsSpectrometer -> spectrometer -> evrClient -> BsaCore -> timingApi`. Three of the modules (spectrometer, evrClient,  BsaCore) all depend on timingApi. 

In yesterday's PR, timingApi was updated to R0.11 in the spectrometer module. This caused problems with BsaCore because updating BsaCore to use timingApi=R0.11 would involve a lot of complicated steps and team discussions. It seems easier to revert timingApi back to R0.9 in the other modules.

I tested the entire dependency chain and `ioc-common-OceanOpticsSpectrometer` with timingApi=R0.9 and everything builds and the IOC runs normally.